### PR TITLE
chore(ops): add standard-linter

### DIFF
--- a/packages/standard-linter/README.md
+++ b/packages/standard-linter/README.md
@@ -1,0 +1,17 @@
+---
+Linter
+---
+
+`@ordzaar/standard-linter`
+
+Standard linter for TS projects that do not run with web frameworks. This module also installs `prettier`, `eslint`, `husky` and `lint-staged`.
+
+Lint rules are extended from these packages
+
+| Package                          | Description                                           |
+| -------------------------------- | ----------------------------------------------------- |
+| @typescript-eslint/parser        | Rules parser for TypeScript.                          |
+| eslint-config-airbnb-base        | Rules defined by airbnb.                              |
+| eslint-config-airbnb-typescript  | Rules defined by airbnb for TypeScript without React. |
+| eslint-plugin-simple-import-sort | Rules defined for simple import sorting.              |
+| prettier                         | Rules defined by prettier to have same code styles    |

--- a/packages/standard-linter/index.js
+++ b/packages/standard-linter/index.js
@@ -1,0 +1,34 @@
+module.exports = {
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "airbnb",
+    "airbnb-typescript/base",
+    "prettier",
+  ],
+  plugins: ["simple-import-sort", "prettier"],
+  parser: "@typescript-eslint/parser",
+  rules: {
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
+    "sort-imports": "off",
+    "import/order": "off",
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+  },
+  overrides: [
+    {
+      files: ["**/**.{test,spec,unit}.{js,ts}"],
+      rules: {
+        "@typescript-eslint/no-floating-promises": "off",
+      },
+    },
+  ],
+};

--- a/packages/standard-linter/package.json
+++ b/packages/standard-linter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ordzaar/standard-linter",
+  "version": "0.0.0",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "eslint": "^8.52.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.1",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "husky": "^8.0.3",
+    "lint-staged": "^15.0.2",
+    "prettier": "^3.0.3",
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/standard-web-linter/index.js
+++ b/packages/standard-web-linter/index.js
@@ -30,5 +30,9 @@ module.exports = {
     curly: ["error", "all"],
     "object-curly-spacing": ["error", "always"],
     "nonblock-statement-body-position": ["error", "below"],
+    "sort-imports": "off",
+    "import/order": "off",
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,45 @@ importers:
         specifier: ^10.2.3
         version: 10.2.3
 
+  packages/standard-linter:
+    dependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.9.1
+        version: 6.9.1(@typescript-eslint/parser@6.9.1)(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/parser':
+        specifier: ^6.9.1
+        version: 6.9.1(eslint@8.52.0)(typescript@5.2.2)
+      eslint:
+        specifier: ^8.52.0
+        version: 8.52.0
+      eslint-config-airbnb-base:
+        specifier: ^15.0.0
+        version: 15.0.0(eslint-plugin-import@2.29.0)(eslint@8.52.0)
+      eslint-config-airbnb-typescript:
+        specifier: ^17.1.0
+        version: 17.1.0(@typescript-eslint/eslint-plugin@6.9.1)(@typescript-eslint/parser@6.9.1)(eslint-plugin-import@2.29.0)(eslint@8.52.0)
+      eslint-config-prettier:
+        specifier: ^9.0.0
+        version: 9.0.0(eslint@8.52.0)
+      eslint-plugin-prettier:
+        specifier: ^5.0.1
+        version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.52.0)(prettier@3.0.3)
+      eslint-plugin-simple-import-sort:
+        specifier: ^10.0.0
+        version: 10.0.0(eslint@8.52.0)
+      husky:
+        specifier: ^8.0.3
+        version: 8.0.3
+      lint-staged:
+        specifier: ^15.0.2
+        version: 15.0.2
+      prettier:
+        specifier: ^3.0.3
+        version: 3.0.3
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
+
   packages/standard-prettier:
     dependencies:
       eslint:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `standard-linter`. This is required for packages that don't use React. (standard-web-linter uses react)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
