### PR TITLE
fix(standard-linter): allow underscore prefix for variables

### DIFF
--- a/packages/standard-linter/index.js
+++ b/packages/standard-linter/index.js
@@ -12,6 +12,15 @@ module.exports = {
     "@typescript-eslint/no-floating-promises": "error",
     "no-console": "error",
 
+    // Fix airbnb-typescript/base rule to allow leading underscores for unused vars
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "variable",
+        format: ["camelCase", "PascalCase", "UPPER_CASE"],
+        leadingUnderscore: "allow",
+      },
+    ],
     /**
      * Separates out the `no-unused-vars` rule depending on it being an import statement in the AST and providing
      * an auto-fix rule to remove the nodes if they are imports.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Allow underscore prefix for variables in standard-linter
- This conflicts with the rule no-unused-vars which already allows underscores

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
