### PR TITLE
fix(standard-linter): reenable naming-convention for other selectors

### DIFF
--- a/packages/standard-linter/index.js
+++ b/packages/standard-linter/index.js
@@ -20,6 +20,14 @@ module.exports = {
         format: ["camelCase", "PascalCase", "UPPER_CASE"],
         leadingUnderscore: "allow",
       },
+      {
+        selector: "function",
+        format: ["camelCase", "PascalCase"],
+      },
+      {
+        selector: "typeLike",
+        format: ["PascalCase"],
+      },
     ],
     /**
      * Separates out the `no-unused-vars` rule depending on it being an import statement in the AST and providing


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Accidentally disabled the naming-convention rule for the other selectors (function, types). This reenables it.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
