### PR TITLE
fix(standard-linter): disallow non-braced statements

### DIFF
--- a/packages/standard-linter/index.js
+++ b/packages/standard-linter/index.js
@@ -11,6 +11,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/no-floating-promises": "error",
     "no-console": "error",
+    curly: "error",
 
     // Fix airbnb-typescript/base rule to allow leading underscores for unused vars
     "@typescript-eslint/naming-convention": [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Disallow non-braced statements. Currently, we use `multi-line` based on [airbnb-base](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/best-practices.js). See [curly](https://eslint.org/docs/latest/rules/curly) rule for more information.

```
if (a) b(); // not allowed anymore
if (a) return; // not allowed anymore
while(true) foo(); // not allowed anymore

// allowed
if (a) {
  b();
}

while (true) {
  foo();
}
```

Non-braced statements affect code clarity when making comments and while debugging, therefore we should wrap conditional code in curly braced block statements.

After this PR, we'll be using `all` by default (more strict than `multi-line`)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Additional comments?:
