### PR TITLE
fix(eslint): no-use-before-define

### DIFF
--- a/packages/standard-linter/index.js
+++ b/packages/standard-linter/index.js
@@ -15,8 +15,8 @@ module.exports = {
     "max-classes-per-file": "off",
     "class-methods-use-this": "off",
     "no-await-in-loop": "off",
-    // functions and classes are going to be hoisted in runtime
-    "no-use-before-define": ["error", { functions: false, classes: false }],
+    // functions and classes are going to be hoisted in runtime, but don't let var be used before declaration
+    "@typescript-eslint/no-use-before-define": ["error", { functions: false, classes: false, variables: true }],
 
     // Fix airbnb-typescript/base rule to allow leading underscores for unused vars
     "@typescript-eslint/naming-convention": [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Use typescript version of `no-use-before-define` since the original version reports wrong errors for TS.

Also re-include other defaults by [airbnb-base](https://github.com/airbnb/javascript/blob/11ab37144b7f846f04f64a29b5beb6e00d74e84b/packages/eslint-config-airbnb-base/rules/variables.js#L57C5-L57C92).

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
