### PR TITLE
fix(eslint): group react imports and internal imports correctly

### DIFF
--- a/packages/standard-web-linter/index.js
+++ b/packages/standard-web-linter/index.js
@@ -35,4 +35,37 @@ module.exports = {
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
   },
+  overrides: [
+    {
+      files: ["*.tsx", ".jsx"],
+      rules: {
+        "simple-import-sort/imports": [
+          "error",
+          {
+            groups: [
+              // External: react, without @ prefix (nextjs), with @ prefix (@ordzaar, @radix-ui, @very-long-package)
+              // Ensures that these are really external packages by excluding:
+              // content, api, contexts, components, hooks, store, utils, public, types
+              // e.g. content/foo and @content/foo is excluded from the group, but not contents/foo and @contents/foo
+              [
+                "^react",
+                "^(?!content\b|api\b|contexts\b|components\b|hooks\b|store\b|utils\b|public\b|types\b|app\b)\\w+",
+                "^@(?!(content|api|contexts|components|hooks|store|utils|public|types|app)\\b)(\\w+|((?:\\w+-)+\\w+))\\b(/.*|$)",
+              ],
+              // Internal packages: @/file, contexts/file, @contexts/file
+              ["^(@|content|api|contexts|components|hooks|store|utils|public|types|app|@\\w+)(/.*|$)"],
+              // Side effect imports.
+              ["^\\u0000"],
+              // Parent imports. Put `..` last.
+              ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
+              // Other relative imports. Put same-folder imports and `.` last.
+              ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
+              // Style imports.
+              ["^.+\\.?(css)$"],
+            ],
+          },
+        ],
+      },
+    },
+  ],
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Imports are being grouped wrongly (yay regex)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

Have tested several files on ordzaar directly, it seems to group correctly. Merging this change would affect all react-based apps and we'll have to re-lint all of them.

file1
```
import { forwardRef, HTMLAttributes, ReactNode } from "react";
import { IoIosInformationCircle } from "react-icons/io";
import BigNumber from "bignumber.js";
import clsx from "clsx";
import { Slot } from "@radix-ui/react-slot";

import NumericFormat from "@components/common/NumericFormat";
import Tooltip from "@components/common/Tooltip";
import { convertToPercentage } from "@utils/textHelper";
```

file2
```
"use client";

import { Fragment, useState } from "react";
import { useRouter } from "next/navigation";
import { useDebouncedValue } from "@mantine/hooks";
import { useOrdContext } from "@ordzaar/ord-connect";

import BuyInscriptionModal from "@components/BuyInscriptionModal";
import AssetOrInscriptionCard from "@components/common/AssetOrInscriptionCard";
import SearchInput from "@components/common/SearchInput";
import SmallButton from "@components/common/SmallButton";
import useCollectionById from "@hooks/api/useCollectionById";
import useInfiniteScrollQuery from "@hooks/useInfiniteScrollQuery";
import { useLazyGetInscriptionsQuery } from "@store/ordzaarApi";
import EmptySection from "app/profile/components/EmptySection";
import { AssetType } from "types/common";
import { Inscription } from "types/inscription";
import { GetInscriptionsQuery } from "types/query";

import { ImportStatus } from "../../../../../../types/collections";
import AssetOrInscriptionCardsLoader from "../component/AssetOrInscriptionCardsLoader";
import EmptySearch from "../component/EmptySearch";
import FilterMenu from "../component/FilterMenu";
import TabPageLayout from "../component/TabPageLayout";
import { MEDIA_TYPES } from "../constants";
```

file3
```
import Link from "next/link";
import process from "process";

import useResponsive from "hooks/useResponsive";
import { truncateTextFromMiddle } from "utils/textHelper";
```