### PR TITLE
fix(standard-web-linter): disable preferring default export

### DIFF
--- a/packages/standard-web-linter/index.js
+++ b/packages/standard-web-linter/index.js
@@ -59,6 +59,7 @@ module.exports = {
     "import/order": "off",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
+    "import/prefer-default-export": "off",
   },
   overrides: [
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Fix: Disable preferring default export

The default export rule is not helpful when it comes to utils which may be expanded to have multiple functions and requires explicitly disabling the rule, but this becomes inconsistent and ends up requiring code refactoring in existing usages where the default exported function is imported in multiple files.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
